### PR TITLE
Strip trailing slash from default warehouse location

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -707,7 +707,8 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
           clients.run(client -> client.getDatabase(tableIdentifier.namespace().levels()[0]));
       if (databaseData.getLocationUri() != null) {
         // If the database location is set use it as a base.
-        return String.format("%s/%s", databaseData.getLocationUri(), tableIdentifier.name());
+        String stripLocationUri = LocationUtil.stripTrailingSlash(databaseData.getLocationUri());
+        return String.format("%s/%s", stripLocationUri, tableIdentifier.name());
       }
 
     } catch (NoSuchObjectException e) {


### PR DESCRIPTION
With native s3 filesystem support in Trino 458 and above, its unable to find the metadata s3 location with `//` and fails the query with location not found error.

This PR strips the trailing slash from the warehouse location to fix this issue.